### PR TITLE
Switch order of operations for scheduler

### DIFF
--- a/src/main/java/de/oliver/fancymorphs/FancyMorphs.java
+++ b/src/main/java/de/oliver/fancymorphs/FancyMorphs.java
@@ -23,7 +23,7 @@ public class FancyMorphs extends JavaPlugin {
 
     public FancyMorphs() {
         INSTANCE = this;
-        scheduler = ServerSoftware.isBukkit() ? new BukkitScheduler(INSTANCE) : new FoliaScheduler(INSTANCE);
+        scheduler = ServerSoftware.isFolia() ? new FoliaScheduler(INSTANCE) : new BukkitScheduler(INSTANCE);
         morphManager = new MorphManager();
     }
 


### PR DESCRIPTION
We should check if the server is Folia while building the scheduler to avoid always defaulting to Bukkit schedulers consistently.